### PR TITLE
feat: Add generatePayLink

### DIFF
--- a/sdk.js
+++ b/sdk.js
@@ -37,13 +37,13 @@ class PaddleSDK {
 	 * @param {boolean} [form] - form parameter (ref: got package)
 	 * @param {boolean} [json] - json parameter (ref: got package)
 	 */
-	_request(path, body = {}, headers = this._getDefaultHeaders(), form = true, json = true) {
+	_request(path, body = {}, headers = {}, form = true, json = true) {
 		const url = this.server + path;
 
 		const options = {
 			body: Object.assign(body, this._getDefaultBody()),
 			form,
-			headers,
+			headers: this._getDefaultHeaders(headers),
 			json,
 			method: 'POST',
 		};
@@ -323,7 +323,7 @@ class PaddleSDK {
      *	});
 	 */
 	generatePayLink(body) {
-		return this._request('/product/generate_pay_link', body , form = false);
+		return this._request('/product/generate_pay_link', body, {}, false);
 	}
 }
 

--- a/sdk.js
+++ b/sdk.js
@@ -34,6 +34,8 @@ class PaddleSDK {
 	 * @param {string} url - url to do request
 	 * @param {object} body - body parameters / object
 	 * @param {object} [headers] - header parameters
+	 * @param {boolean} [form] - form parameter (ref: got package)
+	 * @param {boolean} [json] - json parameter (ref: got package)
 	 */
 	_request(path, body = {}, headers = this._getDefaultHeaders(), form = true, json = true) {
 		const url = this.server + path;
@@ -300,6 +302,28 @@ class PaddleSDK {
 		return this._request('/subscription/users_cancel', {
 			subscription_id: subscriptionID,
 		});
+	}
+
+	/**
+	 * Generate a custom pay link 
+	 *
+	 * @method
+	 * @param {object} body
+	 * @returns {Promise}
+	 * @fulfil {object} - The new pay link url 
+	 *
+	 * @example
+	 * const custom = await client.generatePayLink({
+	 *  "title" : "my custom checkout",
+	 *  "custom_message" : "some custom message"
+	 * 	"prices": [
+	 *		"USD:19.99",
+	 *		"EUR:15.99"
+	 *	 ]
+     *	});
+	 */
+	generatePayLink(body) {
+		return this._request('/product/generate_pay_link', body , form = false);
 	}
 }
 

--- a/sdk.js
+++ b/sdk.js
@@ -35,14 +35,14 @@ class PaddleSDK {
 	 * @param {object} body - body parameters / object
 	 * @param {object} [headers] - header parameters
 	 */
-	_request(path, body = {}, headers = this._getDefaultHeaders()) {
+	_request(path, body = {}, headers = this._getDefaultHeaders(), form = true, json = true) {
 		const url = this.server + path;
 
 		const options = {
 			body: Object.assign(body, this._getDefaultBody()),
-			form: true,
+			form,
 			headers,
-			json: true,
+			json,
 			method: 'POST',
 		};
 


### PR DESCRIPTION
I am using the SDK to for example call 

https://developer.paddle.com/api-reference/product-api/pay-links/createpaylink

where I need to push a body which is a pure json object and not coded as form data, so I need form = false. this change allows me to call _request directly and pass any url and body while still enjoying the auth and other sdk support. 