### PR TITLE
bill immediately

### DIFF
--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -193,13 +193,14 @@ declare class PaddleSDK {
      * @param {number} subscriptionID
      * @param {number} planID
      * @param {boolean} prorate
+	 * @param {boolean} billImmediately
      * @returns {Promise}
      * @fulfill {object} - The result of the operation
      *
      * @example
      * const result = await client.updateSubscriptionPlan(123);
      */
-    updateSubscriptionPlan(subscriptionID: number, planID: number, prorate?: boolean): Promise<any>;
+    updateSubscriptionPlan(subscriptionID: number, planID: number, prorate?: boolean, billImmediately?: boolean): Promise<any>;
     /**
      * Update subscription details, quantity, price and or currency
      *

--- a/sdk.js
+++ b/sdk.js
@@ -308,18 +308,20 @@ class PaddleSDK {
 	 * @param {number} subscriptionID
 	 * @param {number} planID
 	 * @param {boolean} prorate
+	 * @param {boolean} billImmediately
 	 * @returns {Promise}
 	 * @fulfill {object} - The result of the operation
 	 *
 	 * @example
 	 * const result = await client.updateSubscriptionPlan(123);
 	 */
-	updateSubscriptionPlan(subscriptionID, planID, prorate = false) {
+	updateSubscriptionPlan(subscriptionID, planID, prorate = false, billImmediately = false) {
 		return this._request('/subscription/users/update', {
 			body: {
 				subscription_id: subscriptionID,
 				plan_id: planID,
 				prorate,
+				bill_immediately: billImmediately
 			},
 		});
 	}


### PR DESCRIPTION
Paddle's API allows us to bill the difference immediately for the new plan, I use this to apply a new plan with a pro-rated charge.