### PR TITLE
feat: Add `subscriptionID` to `getUsers`

### DIFF
--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -195,6 +195,49 @@ describe('subscription methods', () => {
 
 			expect(scope.isDone()).toBeTruthy();
 		});
+
+		test('filters for subscriptionID', async () => {
+			const expectedBody = {
+				...EXPECTED_BODY,
+				page: 1,
+				subscription_id: SUBSCRIPTION_ID,
+				results_per_page: 200,
+			};
+
+			// https://paddle.com/docs/api-list-users
+			const body = {
+				success: true,
+				response: [
+					{
+						subscription_id: SUBSCRIPTION_ID,
+						plan_id: 496199,
+						user_id: 285846,
+						user_email: 'christian@paddle.com',
+						state: 'active',
+						signup_date: '2015-10-06 09:44:23',
+						last_payment: {
+							amount: 5,
+							currency: 'USD',
+							date: '2015-10-06',
+						},
+						next_payment: {
+							amount: 10,
+							currency: 'USD',
+							date: '2015-11-06',
+						},
+					},
+				],
+			};
+
+			const scope = nock().post(path, expectedBody).reply(200, body);
+
+			const response = await instance.getUsers({
+				subscriptionID: SUBSCRIPTION_ID,
+			});
+
+			expect(response).toEqual(body.response);
+			expect(scope.isDone()).toBeTruthy();
+		});
 	});
 
 	describe('getSubscriptionPayments', () => {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -344,6 +344,7 @@ s	 * @example
 	 * const users = await client.getUsers();
 	 * const users = await client.getUsers({ planID: 123 });
 	 * const users = await client.getUsers({ state: 'active' });
+	 * const users = await client.getUsers({ subscriptionID: 456 });
 	 *
 	 * @note
 	 * If you have a large amount of active users, you will need to create paginated calls to this function.
@@ -353,12 +354,14 @@ s	 * @example
 		resultsPerPage?: number;
 		planID?: string | number;
 		state?: GetSubscriptionUsersBody['state'];
+		subscriptionID?: number;
 	}) {
 		const {
 			page = 1,
 			resultsPerPage = 200,
 			state = null,
 			planID = null,
+			subscriptionID = null,
 		} = options || {};
 
 		const body = {
@@ -366,6 +369,7 @@ s	 * @example
 			...(planID && { plan_id: String(planID) }),
 			results_per_page: resultsPerPage,
 			...(state && { state }),
+			...(subscriptionID && { subscription_id: subscriptionID }),
 		};
 
 		return this._request<

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,11 +60,19 @@ export interface Payment {
 	date: string;
 }
 
+export type SubscriptionUserState =
+	| 'active'
+	| 'past_due'
+	| 'trialing'
+	| 'paused'
+	| 'deleted';
+
 export interface GetSubscriptionUsersBody {
 	page?: number;
 	plan_id?: string;
 	results_per_page?: number;
-	state?: 'active' | 'past_due' | 'trialing' | 'paused' | 'deleted';
+	state?: SubscriptionUserState;
+	subscription_id?: number;
 }
 
 export interface SubscriptionUser {
@@ -75,7 +83,7 @@ export interface SubscriptionUser {
 	marketing_consent: boolean;
 	update_url: string;
 	cancel_url: string;
-	state: string;
+	state: SubscriptionUserState;
 	signup_date: string;
 	last_payment: Payment;
 	payment_information: {


### PR DESCRIPTION
This PR adds the `subscription_id` to the `getUsers` request.

I also included a new type `SubscriptionUserState` and added it in the `SubscriptionUser` interface to provide more type-safety.