### PR TITLE
feat: Support all options for `getSubscriptionPayments`

### DIFF
--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -276,8 +276,8 @@ describe('subscription methods', () => {
 		test('resolves on successful request using options', async () => {
 			const expectedBodyOptions = {
 				...expectedBody,
-				subscription_id: SUBSCRIPTION_ID
-			}
+				subscription_id: SUBSCRIPTION_ID,
+			};
 			const body = {
 				success: true,
 				response: [

--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -247,7 +247,7 @@ describe('subscription methods', () => {
 			plan: PLAN_ID,
 		};
 
-		test('resolves on successful request', async () => {
+		test('resolves on successful request using only planID', async () => {
 			// https://paddle.com/docs/api-list-payments
 			const body = {
 				success: true,
@@ -268,6 +268,38 @@ describe('subscription methods', () => {
 			const scope = nock().post(path, expectedBody).reply(200, body);
 
 			const response = await instance.getSubscriptionPayments(PLAN_ID);
+
+			expect(response).toEqual(body.response);
+			expect(scope.isDone()).toBeTruthy();
+		});
+
+		test('resolves on successful request using options', async () => {
+			const expectedBodyOptions = {
+				...expectedBody,
+				subscription_id: SUBSCRIPTION_ID
+			}
+			const body = {
+				success: true,
+				response: [
+					{
+						id: 8936,
+						subscription_id: 2746,
+						amount: 1,
+						currency: 'USD',
+						payout_date: '2015-10-15',
+						is_paid: 0,
+						receipt_url:
+							'https://www.paddle.com/receipt/469214-8936/1940881-chrea0eb34164b5-f0d6553bdf',
+					},
+				],
+			};
+
+			const scope = nock().post(path, expectedBodyOptions).reply(200, body);
+
+			const response = await instance.getSubscriptionPayments({
+				planID: PLAN_ID,
+				subscriptionID: SUBSCRIPTION_ID,
+			});
 
 			expect(response).toEqual(body.response);
 			expect(scope.isDone()).toBeTruthy();

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -137,14 +137,42 @@ s	 * @example
 	 *
 	 * @example
 	 * const payments = await client.getSubscriptionPayments();
+	 * const payments = await client.getSubscriptionPayments({ subscriptionID: 123 });
+	 * Legacy usage for backwards compatibility: pass planID as a number instead of options object
 	 * const payments = await client.getSubscriptionPayments(123);
 	 */
-	getSubscriptionPayments(planID?: number) {
+	getSubscriptionPayments(options?: number | {
+		planID?: number;
+		subscriptionID?: number;
+		isPaid?: boolean;
+		from?: Date;
+		to?: Date;
+		isOneOffCharge?: boolean;
+	}) {
+		const opts = (typeof options === 'number') ? { planID: options } : options;
+		const {
+			planID = null,
+			subscriptionID = null,
+			isPaid = null,
+			from = null,
+			to = null,
+			isOneOffCharge = null,
+		} = opts || {};
+
+		const body = {
+			...(planID && { plan: planID }),
+			...(subscriptionID && { subscription_id: subscriptionID }),
+			...(typeof isPaid === 'boolean' && { is_paid: Number(isPaid) }),
+			...(from && { from: from.toISOString().substring(0, 10) }),
+			...(to && { to: to.toISOString().substring(0, 10) }),
+			...(typeof isOneOffCharge === 'boolean' && { is_one_off_charge: Number(isOneOffCharge) }),
+		};
+
 		return this._request<
 			GetSubscriptionPaymentsResponse,
 			GetSubscriptionPaymentsBody
 		>('/subscription/payments', {
-			body: { plan: planID },
+			body,
 		});
 	}
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -141,15 +141,24 @@ s	 * @example
 	 * Legacy usage for backwards compatibility: pass planID as a number instead of options object
 	 * const payments = await client.getSubscriptionPayments(123);
 	 */
-	getSubscriptionPayments(options?: number | {
-		planID?: number;
-		subscriptionID?: number;
-		isPaid?: boolean;
-		from?: Date;
-		to?: Date;
-		isOneOffCharge?: boolean;
-	}) {
-		const opts = (typeof options === 'number') ? { planID: options } : options;
+	getSubscriptionPayments(
+		options?:
+			| number
+			| {
+					planID?: number;
+					subscriptionID?: number;
+					isPaid?: boolean;
+					from?: Date;
+					to?: Date;
+					isOneOffCharge?: boolean;
+			  }
+	) {
+		if (typeof options === 'number') {
+			console.warn(
+				'Passing planID as a number is deprecated, please use an options object instead'
+			);
+		}
+		const opts = typeof options === 'number' ? { planID: options } : options;
 		const {
 			planID = null,
 			subscriptionID = null,
@@ -159,20 +168,20 @@ s	 * @example
 			isOneOffCharge = null,
 		} = opts || {};
 
-		const body = {
-			...(planID && { plan: planID }),
-			...(subscriptionID && { subscription_id: subscriptionID }),
-			...(typeof isPaid === 'boolean' && { is_paid: Number(isPaid) }),
-			...(from && { from: from.toISOString().substring(0, 10) }),
-			...(to && { to: to.toISOString().substring(0, 10) }),
-			...(typeof isOneOffCharge === 'boolean' && { is_one_off_charge: Number(isOneOffCharge) }),
-		};
-
 		return this._request<
 			GetSubscriptionPaymentsResponse,
 			GetSubscriptionPaymentsBody
 		>('/subscription/payments', {
-			body,
+			body: {
+				...(planID && { plan: planID }),
+				...(subscriptionID && { subscription_id: subscriptionID }),
+				...(typeof isPaid === 'boolean' && { is_paid: Number(isPaid) }),
+				...(from && { from: from.toISOString().substring(0, 10) }),
+				...(to && { to: to.toISOString().substring(0, 10) }),
+				...(typeof isOneOffCharge === 'boolean' && {
+					is_one_off_charge: Number(isOneOffCharge),
+				}),
+			},
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,12 +94,20 @@ export interface SubscriptionUser {
 	};
 	quantity: number;
 	next_payment: Payment;
+	paused_at?: string
+	paused_from?: string
+	paused_reason?: string
 }
 
 export type GetSubscriptionUsersResponse = Array<SubscriptionUser>;
 
 export interface GetSubscriptionPaymentsBody {
 	plan?: number;
+	subscription_id?: number
+	is_paid?: number
+	from?: string
+	to?: string
+	isOneOffCharge?: number
 }
 
 export interface SubscriptionPayment {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,20 +94,20 @@ export interface SubscriptionUser {
 	};
 	quantity: number;
 	next_payment: Payment;
-	paused_at?: string
-	paused_from?: string
-	paused_reason?: string
+	paused_at?: string;
+	paused_from?: string;
+	paused_reason?: string;
 }
 
 export type GetSubscriptionUsersResponse = Array<SubscriptionUser>;
 
 export interface GetSubscriptionPaymentsBody {
 	plan?: number;
-	subscription_id?: number
-	is_paid?: number
-	from?: string
-	to?: string
-	isOneOffCharge?: number
+	subscription_id?: number;
+	is_paid?: number;
+	from?: string;
+	to?: string;
+	isOneOffCharge?: number;
 }
 
 export interface SubscriptionPayment {


### PR DESCRIPTION
This PR adds support for all available parameters for the list payments API to `getSubscriptionPayments`. It maintains backward compatibility. Tests are included for both the legacy and new parameters.

It also adds some missing properties to the `SubscriptionUser` interface.