### PR TITLE
feat: Support the One-off Charge API

### DIFF
--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -544,7 +544,8 @@ describe('subscription methods', () => {
 				amount: '10.00',
 				currency: 'USD',
 				payment_date: '2018-09-21',
-				receipt_url: 'https://my.paddle.com/receipt/1-1/3-chre8a53a2724c6-42781cb91a',
+				receipt_url:
+					'https://my.paddle.com/receipt/1-1/3-chre8a53a2724c6-42781cb91a',
 				status: 'success',
 			},
 		};
@@ -555,7 +556,7 @@ describe('subscription methods', () => {
 			const response = await instance.createOneOffCharge(
 				SUBSCRIPTION_ID,
 				10,
-				'Charge 1',
+				'Charge 1'
 			);
 
 			expect(response).toEqual(responseBody.response);

--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -527,4 +527,49 @@ describe('subscription methods', () => {
 			expect(scope.isDone()).toBeTruthy();
 		});
 	});
+
+	describe('createOneOffCharge', () => {
+		const path = `/subscription/${SUBSCRIPTION_ID}/charge`;
+		const expectedBody = {
+			...EXPECTED_BODY,
+			amount: 10,
+			charge_name: 'Charge 1',
+		};
+		// https://developer.paddle.com/api-reference/23cf86225523f-create-one-off-charge
+		const responseBody = {
+			success: true,
+			response: {
+				invoice_id: 1,
+				subscription_id: SUBSCRIPTION_ID,
+				amount: '10.00',
+				currency: 'USD',
+				payment_date: '2018-09-21',
+				receipt_url: 'https://my.paddle.com/receipt/1-1/3-chre8a53a2724c6-42781cb91a',
+				status: 'success',
+			},
+		};
+
+		test('resolves on successful request', async () => {
+			const scope = nock().post(path, expectedBody).reply(200, responseBody);
+
+			const response = await instance.createOneOffCharge(
+				SUBSCRIPTION_ID,
+				10,
+				'Charge 1',
+			);
+
+			expect(response).toEqual(responseBody.response);
+			expect(scope.isDone()).toBeTruthy();
+		});
+
+		test('rejects on error request', async () => {
+			const scope = nock().post(path, expectedBody).reply(400, DEFAULT_ERROR);
+
+			await expect(
+				instance.createOneOffCharge(SUBSCRIPTION_ID, 10, 'Charge 1')
+			).rejects.toThrow('Request failed with status code 400');
+
+			expect(scope.isDone()).toBeTruthy();
+		});
+	});
 });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -5,6 +5,8 @@ import serialize from './serialize';
 import {
 	CreateSubscriptionModifierBody,
 	CreateSubscriptionModifierResponse,
+	CreateOneOffChargeBody,
+	CreateOneOffChargeResponse,
 	GeneratePaylinkBody,
 	GeneratePaylinkResponse,
 	GetProductCouponsBody,
@@ -470,6 +472,27 @@ s	 * @example
 			CreateSubscriptionModifierResponse,
 			CreateSubscriptionModifierBody
 		>('/subscription/modifiers/create', {
+			body,
+		});
+	}
+
+	/**
+	 * Make an immediate one-off charge on top of an existing user subscription
+	 * 
+	 * API documentation: https://developer.paddle.com/api-reference/23cf86225523f-create-one-off-charge
+	 * 
+	 * @example
+	 * const result = await client.createOneOffCharge(123, 10, 'description');
+	 */
+	createOneOffCharge(subscriptionID: number, amount: number, chargeName: string) {
+		const body = {
+			amount,
+			charge_name: chargeName.substring(0, 50),
+		}
+		return this._request<
+			CreateOneOffChargeResponse,
+			CreateOneOffChargeBody
+		>(`/subscription/${subscriptionID}/charge`, {
 			body,
 		});
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -478,23 +478,27 @@ s	 * @example
 
 	/**
 	 * Make an immediate one-off charge on top of an existing user subscription
-	 * 
+	 *
 	 * API documentation: https://developer.paddle.com/api-reference/23cf86225523f-create-one-off-charge
-	 * 
+	 *
 	 * @example
 	 * const result = await client.createOneOffCharge(123, 10, 'description');
 	 */
-	createOneOffCharge(subscriptionID: number, amount: number, chargeName: string) {
+	createOneOffCharge(
+		subscriptionID: number,
+		amount: number,
+		chargeName: string
+	) {
 		const body = {
 			amount,
 			charge_name: chargeName.substring(0, 50),
-		}
-		return this._request<
-			CreateOneOffChargeResponse,
-			CreateOneOffChargeBody
-		>(`/subscription/${subscriptionID}/charge`, {
-			body,
-		});
+		};
+		return this._request<CreateOneOffChargeResponse, CreateOneOffChargeBody>(
+			`/subscription/${subscriptionID}/charge`,
+			{
+				body,
+			}
+		);
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,22 @@ export interface CreateSubscriptionModifierResponse {
 	modifier_id: number;
 }
 
+export interface CreateOneOffChargeBody {
+	amount: number;
+	charge_name: string;
+}
+
+export interface CreateOneOffChargeResponse {
+	subscription_id: number;
+	invoice_id: number;
+	amount: string;
+	currency: string;
+	payment_date: string;
+	receipt_url: string;
+	order_id: string;
+	status: 'success' | 'pending';
+}
+
 export interface RescheduleSubscriptionPaymentBody {
 	date: string;
 	payment_id: number;


### PR DESCRIPTION
Adds `client.createOneOffCharge` based on https://developer.paddle.com/api-reference/23cf86225523f-create-one-off-charge

Tests are included, but no version bump or build has been done (not sure how to do that correctly for this repo).