### PR TITLE
feat: custom error class with code and message

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -24,6 +24,7 @@ import {
 	RescheduleSubscriptionPaymentBody,
 	UpdateSubscriptionUserBody,
 	UpdateSubscriptionUserResponse,
+	PaddleResponseError,
 } from './types';
 import { VERSION } from './version';
 
@@ -573,8 +574,9 @@ s	 * @example
 				return response || data.success;
 			}
 
-			throw new Error(
-				`Request ${url} returned an error! response=${JSON.stringify(data)}`
+			throw new PaddleRequestError(
+				`Request ${url} returned an error! response=${JSON.stringify(data)}`,
+				data.error
 			);
 		}
 
@@ -607,5 +609,17 @@ s	 * @example
 			`/${type}/${id}/transactions`,
 			page ? { body: { page } } : undefined
 		);
+	}
+}
+
+class PaddleRequestError extends Error {
+	paddleCode: number;
+	paddleMessage: string;
+
+	constructor(message: string, error: PaddleResponseError) {
+		super(message);
+		this.name = 'PaddleRequestError';
+		this.paddleCode = error.code;
+		this.paddleMessage = error.message;
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,20 @@ export interface Product {
 	screenshots: object[];
 }
 
-export interface PaddleResponseWrap<TResponse> {
-	success: boolean;
-	response: TResponse;
+export interface PaddleResponseError {
+	code: number;
+	message: string;
 }
+
+export type PaddleResponseWrap<TResponse> =
+	| {
+			success: true;
+			response: TResponse;
+	  }
+	| {
+			success: false;
+			error: PaddleResponseError;
+	  };
 
 export interface GetProductsResponse {
 	count: number;


### PR DESCRIPTION
The current error thrown by the sdk doesn't give us access to the Paddle error code and message without parsing it in a way that is probably not going to be future-friendly.

This PR updates the sdk to throw a custom error that has `paddleCode` and `paddleMessage` properties so that they can be accessed programatically.