### PR TITLE
fix: add 'passthrough' when updating a subscription

### DIFF
--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -366,6 +366,7 @@ describe('subscription methods', () => {
 			quantity: 2,
 			recurring_price: 25.5,
 			currency: 'GBP',
+			passthrough: '12345',
 		};
 		// https://developer.paddle.com/api-reference/subscription-api/subscription-users/updateuser
 		const responseBody = {
@@ -385,6 +386,7 @@ describe('subscription methods', () => {
 				quantity: 2,
 				price: 25.5,
 				currency: 'GBP',
+				passthrough: '12345',
 			});
 
 			expect(response).toEqual(responseBody.response);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -319,6 +319,7 @@ s	 * @example
 			billImmediately?: boolean;
 			currency?: string;
 			keepModifiers?: boolean;
+			passthrough?: string;
 			pause?: boolean;
 			planID?: number;
 			prorate?: boolean;
@@ -334,12 +335,14 @@ s	 * @example
 			prorate,
 			keepModifiers,
 			billImmediately,
+			passthrough,
 			pause,
 		} = postData;
 
 		const body = {
 			subscription_id: subscriptionID,
 			...(currency && { currency }),
+			...(passthrough && { passthrough }),
 			...(typeof keepModifiers === 'boolean' && {
 				keep_modifiers: keepModifiers,
 			}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,7 @@ export interface UpdateSubscriptionUserBody {
 	bill_immediately?: boolean;
 	currency?: string;
 	keep_modifiers?: boolean;
+	passthrough?: string;
 	plan_id?: number;
 	prorate?: boolean;
 	recurring_price?: number;


### PR DESCRIPTION
I added the `passthrough` param to the `udpateSubscription` function and its related type (`UpdateSubscriptionUserBody `).

I've also updated the test with all the params to include the `passthrough`.

Closes #86 