### PR TITLE
feat: get subscription modifiers

### DIFF
--- a/src/__tests__/subscriptions.test.ts
+++ b/src/__tests__/subscriptions.test.ts
@@ -1,4 +1,3 @@
-import { PaddleSDK } from '../sdk';
 import {
 	DEFAULT_ERROR,
 	EXPECTED_BODY,
@@ -6,6 +5,7 @@ import {
 	VENDOR_ID,
 } from '../../utils/constants';
 import nock, { SERVER } from '../../utils/nock';
+import { PaddleSDK } from '../sdk';
 
 describe('subscription methods', () => {
 	let instance: PaddleSDK;
@@ -492,6 +492,64 @@ describe('subscription methods', () => {
 			await expect(
 				instance.cancelSubscription(SUBSCRIPTION_ID)
 			).rejects.toThrow('Request failed with status code 400');
+
+			expect(scope.isDone()).toBeTruthy();
+		});
+	});
+
+	describe('getSubscriptionModifiers', () => {
+		const path = '/subscription/modifiers';
+		const expectedBody = {
+			...EXPECTED_BODY,
+		};
+		// https://developer.paddle.com/api-reference/f575ab89eb18c-list-modifiers
+		const responseBody = {
+			success: true,
+			response: {
+				subscription_id: SUBSCRIPTION_ID,
+				modifier_id: 1,
+				amount: '100',
+				currency: 'GBP',
+				is_recurring: true,
+				description: 'Support',
+			},
+		};
+
+		test('resolves on successful request', async () => {
+			const scope = nock().post(path, expectedBody).reply(200, responseBody);
+
+			const response = await instance.getSubscriptionModifiers();
+
+			expect(response).toEqual(responseBody.response);
+			expect(scope.isDone()).toBeTruthy();
+		});
+
+		test('resolves on successful request all params', async () => {
+			const expectedBody = Object.assign(
+				{
+					subscription_id: SUBSCRIPTION_ID,
+					plan_id: PLAN_ID,
+				},
+				EXPECTED_BODY
+			);
+
+			const scope = nock().post(path, expectedBody).reply(200, responseBody);
+
+			const response = await instance.getSubscriptionModifiers({
+				subscriptionID: SUBSCRIPTION_ID + '',
+				planID: PLAN_ID + '',
+			});
+
+			expect(response).toEqual(responseBody.response);
+			expect(scope.isDone()).toBeTruthy();
+		});
+
+		test('rejects on error request', async () => {
+			const scope = nock().post(path, expectedBody).reply(400, DEFAULT_ERROR);
+
+			await expect(instance.getSubscriptionModifiers()).rejects.toThrow(
+				'Request failed with status code 400'
+			);
 
 			expect(scope.isDone()).toBeTruthy();
 		});

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,17 +1,19 @@
-import crypto from 'crypto';
 import axios, { AxiosRequestConfig } from 'axios';
+import crypto from 'crypto';
 
 import serialize from './serialize';
 import {
-	CreateSubscriptionModifierBody,
-	CreateSubscriptionModifierResponse,
 	CreateOneOffChargeBody,
 	CreateOneOffChargeResponse,
+	CreateSubscriptionModifierBody,
+	CreateSubscriptionModifierResponse,
 	GeneratePaylinkBody,
 	GeneratePaylinkResponse,
 	GetProductCouponsBody,
 	GetProductCouponsResponse,
 	GetProductsResponse,
+	GetSubscriptionModifiersBody,
+	GetSubscriptionModifiersResponse,
 	GetSubscriptionPaymentsBody,
 	GetSubscriptionPaymentsResponse,
 	GetSubscriptionPlansBody,
@@ -20,11 +22,11 @@ import {
 	GetSubscriptionUsersResponse,
 	GetTransactionsResponse,
 	GetWebhookHistoryResponse,
+	PaddleResponseError,
 	PaddleResponseWrap,
 	RescheduleSubscriptionPaymentBody,
 	UpdateSubscriptionUserBody,
 	UpdateSubscriptionUserResponse,
-	PaddleResponseError,
 } from './types';
 import { VERSION } from './version';
 
@@ -478,6 +480,34 @@ s	 * @example
 	getOrderDetails(checkoutID: string) {
 		return this._request(`/order?checkout_id=${checkoutID}`, {
 			checkoutAPI: true,
+		});
+	}
+
+	/**
+	 * Get subscription modifiers.
+	 *
+	 * API documentation: https://developer.paddle.com/api-reference/f575ab89eb18c-list-modifiers
+	 *
+	 * @example
+	 * const result = await client.getSubscriptionModifiers();
+	 * const result = await client.getSubscriptionModifiers({ subscriptionID: 123 });
+	 */
+	getSubscriptionModifiers(options?: {
+		subscriptionID?: string;
+		planID?: string;
+	}) {
+		const { subscriptionID, planID } = options || {};
+
+		const body = {
+			...(subscriptionID && { subscription_id: subscriptionID }),
+			...(planID && { plan_id: planID }),
+		};
+
+		return this._request<
+			GetSubscriptionModifiersResponse,
+			GetSubscriptionModifiersBody
+		>('/subscription/modifiers', {
+			body,
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,20 @@ export interface UpdateSubscriptionUserResponse {
 	next_payment: Payment;
 }
 
+export interface GetSubscriptionModifiersBody {
+	plan_id?: string;
+	subscription_id?: string;
+}
+
+export interface GetSubscriptionModifiersResponse {
+	modifier_id: number;
+	subscription_id: number;
+	amount: number;
+	currency: number;
+	is_recurring: boolean;
+	description: string;
+}
+
 export interface CreateSubscriptionModifierBody {
 	modifier_amount: number;
 	modifier_description?: string;


### PR DESCRIPTION
Adding support for [List Modifiers](https://developer.paddle.com/api-reference/f575ab89eb18c-list-modifiers).

A bit of inconsistency on the Paddle side with the API, where the `subscription_id` and `plan_id` are of type `string` rather than `number`. IMO it would be nice to hide this from calling code and stick with the usual `number` types.

I couldn't find any examples of this in the other methods so have left it as a 1-1 mapping with Paddle for now but happy to change it if we get an agreement.