### PR TITLE
fix: add getPrices response type

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -9,6 +9,7 @@ import {
 	CreateSubscriptionModifierResponse,
 	GeneratePaylinkBody,
 	GeneratePaylinkResponse,
+	GetPricesResponse,
 	GetProductCouponsBody,
 	GetProductCouponsResponse,
 	GetProductsResponse,
@@ -514,7 +515,7 @@ s	 * @example
 			...(customerIp && { customer_ip: customerIp }),
 		});
 
-		return this._request(`/prices?${params.toString()}`, {
+		return this._request<GetPricesResponse>(`/prices?${params.toString()}`, {
 			checkoutAPIVersion: 'v2',
 		});
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,3 +262,27 @@ export interface GeneratePaylinkBody {
 export interface GeneratePaylinkResponse {
 	url: string;
 }
+
+export interface GetPricesResponse {
+	customer_country: string;
+	products: {
+		product_id: number;
+		product_title: string;
+		currency: string;
+		vendor_set_prices_included_tax: boolean;
+		price: {
+			gross: number;
+			net: number;
+			tax: number;
+		};
+		list_price: {
+			gross: number;
+			net: number;
+			tax: number;
+		};
+		applied_coupon: {
+			code: string;
+			discount: number;
+		};
+	}[];
+}


### PR DESCRIPTION
Noticed I missed adding the response type when adding support for `getPrices`.