### PR TITLE
fix: Fix type of `recurring_prices` in `GeneratePaylinkBody`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -250,7 +250,7 @@ export interface GeneratePaylinkBody {
 	product_id?: number;
 	quantity_variable?: number;
 	quantity?: number;
-	recurring_prices?: string;
+	recurring_prices?: Array<string>;
 	return_url?: string;
 	title?: string;
 	trial_days?: number;


### PR DESCRIPTION
Sending `recurring_prices` as a string will lead to this error from the Paddle API:

```json
{
  "success": false,
  "error": {
    "code": 142,
    "message": "The given recurring prices format is not valid. The recurring prices must have the format of ['currency:amount', 'currency:amount', …]."
  }
}
```

It's supposed to be a string array, just like `prices`.